### PR TITLE
Adding JetBrains to the gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 logs
 *.log
 
+# JetBrains
+.idea
+
 # Runtime data
 pids
 *.pid


### PR DESCRIPTION
Adding the .idea folder from the JetBrains IDEs (WebStorm, PyCharm, etc.) to the .gitignore file